### PR TITLE
Spacing tables

### DIFF
--- a/ticdat/testing/ticdattestutils.py
+++ b/ticdat/testing/ticdattestutils.py
@@ -359,3 +359,16 @@ def spacesData() :
                       ("a", "b", 12, 24) )
     }
 
+def xlsExamine(xls_file_path):
+    assert os.path.isfile(xls_file_path)
+    import xlrd
+    import ticdat.utils
+    try :
+        book = xlrd.open_workbook(xls_file_path)
+    except Exception as e:
+        raise ticdat.utils.TicDatError("Unable to open %s as xls file : %s"%(xls_file_path, e.message))
+    rtn = {}
+    for sheet in book.sheets():
+        rtn[sheet.name] = sheet.row_values(0)
+    return rtn
+

--- a/ticdat/testing/ticdattestutils.py
+++ b/ticdat/testing/ticdattestutils.py
@@ -343,3 +343,19 @@ def sillyMeData() :
         "b" : {(1, 2, 3) : 1, ("a", "b", "b") : 12},
         "c" : ((1, 2, 3, 4), ("a", "b", "c", "d"), ("a", "b", 12, 24) )
     }
+
+def spacesSchema() :
+    return {"a_table" : [("a Field",),("a Data 1", "a Data 2", "a Data 3") ],
+            "b_table" : [("b Field 1", "b Field 2", "b Field 3"), ["b Data"]],
+            "c_table" : [[],("c Data 1", "c Data 2", "c Data 3", "c Data 4")]}
+
+def spacesData() :
+    return {
+        "a_table" : {1 : {"a Data 3":3, "a Data 2":2, "a Data 1":1},
+                     "b" : ("b", "d", 12), 0.23 : (11, 12, "thirt")},
+        "b_table" : {(1, 2, 3) : 1, ("a", "b", "b") : 12},
+        "c_table" : ((1, 2, 3, 4),
+                      {"c Data 4":"d", "c Data 2":"b", "c Data 3":"c", "c Data 1":"a"},
+                      ("a", "b", 12, 24) )
+    }
+

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -408,6 +408,7 @@ foreign keys, the code throwing this exception will be removed.
         self._linkName = {}
         verify(not any(x.startswith("_") for x in init_fields),
                "table names shouldn't start with underscore")
+        verify(not any(" " in x for x in init_fields), "table names shouldn't have white space")
         for k,v in init_fields.items():
             verify(containerish(v) and len(v) == 2 and all(containerish(_) for _ in v),
                    ("Table %s needs to specify two sublists, " +

--- a/ticdat/xls.py
+++ b/ticdat/xls.py
@@ -46,7 +46,9 @@ class XlsTicFactory(freezable_factory(object, "_isFrozen")) :
         :return: a TicDat object populated by the matching sheets.
         caveats: Missing sheets resolve to an empty table, but missing fields
                  on matching sheets throw an Exception.
-                 Sheet names are considered case insensitive
+                 Sheet names are considered case insensitive, and white space is replaced
+                 with underscore for table name matching. (ticdat supports whitespace in
+                 field names but not table names).
                  Any field for which an empty string is invalid data and None is valid data
                  will replace the empty string with None. (This caveat requires the data_types
                  to be set for the ticDatFactory)
@@ -70,7 +72,7 @@ class XlsTicFactory(freezable_factory(object, "_isFrozen")) :
             raise TicDatError("Unable to open %s as xls file : %s"%(xls_file_path, e.message))
         sheets = defaultdict(list)
         for table, sheet in product(all_tables, book.sheets()) :
-            if table.lower() == sheet.name.lower() :
+            if table.lower() == sheet.name.lower().replace(' ', '_'):
                 sheets[table].append(sheet)
         duplicated_sheets = tuple(_t for _t,_s in sheets.items() if len(_s) > 1)
         verify(not duplicated_sheets, "The following sheet names were duplicated : " +


### PR DESCRIPTION
Sometimes people like whitespace in table and field names. (Sigh). `ticdat` can support whitespace in field names, and has some utility code to assist with white space in table names. The latter is currently implemented in excel only but will be added to other formats if important.