### PR TITLE
Generic tables support for Excel, SQLite and csv

### DIFF
--- a/examples/cplex/cog/cogmodel.py
+++ b/examples/cplex/cog/cogmodel.py
@@ -1,6 +1,19 @@
 #!/usr/bin/python
-
+#
 # Copyright 2015, Opalytics, Inc
+#
+# Be advised - although this is the first ticdat example alphabetically, it is not the
+# first example intellectually. I strongly recommend beginning with the diet example,
+# and follow that with either netflow/simplest_version or fantop. These three examples
+# demonstrate the ability of ticdat to easily provide a command line interface
+# (complete with sanity checking of the input data) that can accommodate a variety
+# of file formats.
+#
+# This example demonstrates a script that is capable of fully exploiting all the bells and
+# whistles of the Opalytics Cloud Platform. It pre-diagnoses infeasibility conditions and
+# records them in a log file. It also keeps track of the MIP progress, and allows for the user
+# to terminate the solve prior to achieving the "a priori" goal for the optimization gap.
+#
 #
 # Solve the Center of Gravity problem from _A Deep Dive into Strategic Network Design Programming_
 # http://amzn.to/1Lbd6By

--- a/examples/cplex/fantop/fantopmodel.py
+++ b/examples/cplex/fantop/fantopmodel.py
@@ -1,5 +1,5 @@
 #
-# Author: Pete Cacioppi Opalytics.com
+# Author: Pete Cacioppi Opalytics.com https://lnkd.in/bUhfyNn
 #
 # Solves a fantasy football drafting problem. Tries to maximize the weighted
 # expected points of a draft, while obeying min/max restrictions for different

--- a/examples/cplex/fantop/fantopmodel.py
+++ b/examples/cplex/fantop/fantopmodel.py
@@ -1,0 +1,175 @@
+#
+# Author: Pete Cacioppi Opalytics.com
+#
+# Solves a fantasy football drafting problem. Tries to maximize the weighted
+# expected points of a draft, while obeying min/max restrictions for different
+# positions (to include a maximum-flex-players constraint).
+#
+# Pre-computes the expected draft position of each player, so as to prevent
+# creating an draft plan based on unrealistic expectations of player availability
+# at each round.
+#
+# The current draft standing can be filled in as you go in the drafted table.
+# A user can thus re-optimize for each of his draft picks.
+#
+# Uses the ticdat package to simplify file IO and provide command line functionality.
+# Can read from .csv, Access, Excel or SQLite files. Self validates the input data
+# before solving to prevent strange errors or garbage-in, garbage-out problems.
+
+from ticdat import TicDatFactory, standard_main
+
+
+# this version of the file uses CPLEX
+from docplex.mp.model import Model
+
+# ------------------------ define the input schema --------------------------------
+dataFactory = TicDatFactory (
+ parameters = [["Key"],["Value"]],
+ players = [['Player Name'],
+            ['Position', 'Average Draft Position', 'Expected Points']],
+ roster_requirements = [['Position'],
+                       ['Min Num Starters', 'Max Num Starters', 'Min Num Reserve', 'Max Num Reserve',
+                        'Flex Status']],
+ drafted = [['Player Name'], ['Draft Position']],
+ my_draft_positions = [['Draft Position'],[]]
+)
+
+# add foreign key constraints (optional, but helps with preventing garbage-in, garbage-out)
+dataFactory.add_foreign_key("drafted", "players", ['Player Name', 'Player Name'])
+dataFactory.add_foreign_key("players", "roster_requirements", ['Position', 'Position'])
+
+# set data types (optional, but helps with preventing garbage-in, garbage-out)
+dataFactory.set_data_type("parameters", "Key", number_allowed = False,
+                          strings_allowed = ["Starter Weight", "Reserve Weight",
+                                             "Maximum Number of Flex Starters"])
+dataFactory.set_data_type("parameters", "Value", min=0, max=float("inf"),
+                          inclusive_min = True, inclusive_max = False)
+dataFactory.set_data_type("players", "Average Draft Position", min=0, max=float("inf"),
+                          inclusive_min = False, inclusive_max = False)
+dataFactory.set_data_type("players", "Expected Points", min=-float("inf"), max=float("inf"),
+                          inclusive_min = False, inclusive_max = False)
+for fld in ("Min Num Starters",  "Min Num Reserve", "Max Num Reserve"):
+    dataFactory.set_data_type("roster_requirements", fld, min=0, max=float("inf"),
+                          inclusive_min = True, inclusive_max = False, must_be_int = True)
+dataFactory.set_data_type("roster_requirements", "Max Num Starters", min=0, max=float("inf"),
+                      inclusive_min = False, inclusive_max = True, must_be_int = True)
+dataFactory.set_data_type("roster_requirements", "Flex Status", number_allowed = False,
+                          strings_allowed = ["Flex Eligible", "Flex Ineligible"])
+for tbl in ("drafted", "my_draft_positions"):
+    dataFactory.set_data_type(tbl, "Draft Position", min=0, max=float("inf"),
+                          inclusive_min = False, inclusive_max = False, must_be_int = True)
+# ---------------------------------------------------------------------------------
+
+
+# ------------------------ define the output schema -------------------------------
+solutionFactory = TicDatFactory(
+        my_draft = [['Player Name'], ['Draft Position', 'Position', 'Planned Or Actual',
+                                     'Starter Or Reserve']])
+# ---------------------------------------------------------------------------------
+
+
+# ------------------------ create a solve function --------------------------------
+def solve(dat):
+    assert dataFactory.good_tic_dat_object(dat)
+    assert not dataFactory.find_foreign_key_failures(dat)
+    assert not dataFactory.find_data_type_failures(dat)
+    if dat.drafted:
+        draft_positions = {x["Draft Position"] for x in dat.drafted.values()}
+        assert min(draft_positions) == 1 and len(draft_positions) == max(draft_positions), \
+               "draft positions should be sequential"
+
+    # if a player has already been drafted, then we know his expected draft position
+    expected_draft_position = {player_name:row["Draft Position"] for player_name,row in
+                               dat.drafted.items()}
+    # the undrafted players are then sorted by their average draft position
+    for player_name in sorted([p for p in set(dat.players).difference(expected_draft_position)],
+                                          key=lambda _p: dat.players[_p]["Average Draft Position"]):
+        expected_draft_position[player_name] = len(expected_draft_position) + 1
+    assert max(expected_draft_position.values()) == len(set(expected_draft_position.values())) == len(dat.players)
+    assert min(expected_draft_position.values()) == 1
+
+    already_drafted_by_me = {player_name for player_name in dat.drafted if
+                             dat.drafted[player_name]["Draft Position"] in dat.my_draft_positions}
+    can_be_drafted_by_me = set(dat.players).difference(dat.drafted).union(already_drafted_by_me)
+    m = Model('fantop')
+    my_starters = {}
+    my_reserves = {}
+    for player_name in can_be_drafted_by_me:
+        my_starters[player_name] = m.binary_var(name="starter_%s"%player_name)
+        my_reserves[player_name] = m.binary_var(name="reserve_%s"%player_name)
+
+
+
+    for player_name in can_be_drafted_by_me:
+        if player_name in already_drafted_by_me:
+            m.add_constraint(my_starters[player_name] + my_reserves[player_name] == 1,
+                             ctname="already_drafted_%s"%player_name)
+        else:
+            m.add_constraint(my_starters[player_name] + my_reserves[player_name] <= 1,
+                             ctname="cant_draft_twice_%s"%player_name)
+
+    for i,draft_position in enumerate(sorted(dat.my_draft_positions)):
+        m.add_constraint(m.sum(my_starters[player_name] + my_reserves[player_name]
+                                for player_name in can_be_drafted_by_me
+                                if expected_draft_position[player_name] < draft_position) <= i,
+                    ctname = "at_most_%s_can_be_ahead_of_%s"%(i,draft_position))
+
+    my_draft_size = m.sum(my_starters[player_name] + my_reserves[player_name]
+                          for player_name in can_be_drafted_by_me)
+    m.add_constraint(my_draft_size >= len(already_drafted_by_me) + 1, ctname = "need_to_extend_by_at_least_one")
+    m.add_constraint(my_draft_size <= len(dat.my_draft_positions), ctname = "cant_exceed_draft_total")
+
+    for position, row in dat.roster_requirements.items():
+        players = {player_name for player_name in can_be_drafted_by_me
+                   if dat.players[player_name]["Position"] == position}
+        starters = m.sum(my_starters[player_name] for player_name in players)
+        reserves = m.sum(my_reserves[player_name] for player_name in players)
+        m.add_constraint(starters >= row["Min Num Starters"], ctname = "min_starters_%s"%position)
+        m.add_constraint(starters <= row["Max Num Starters"], ctname = "max_starters_%s"%position)
+        m.add_constraint(reserves >= row["Min Num Reserve"], ctname = "min_reserve_%s"%position)
+        m.add_constraint(reserves <= row["Max Num Reserve"], ctname = "max_reserve_%s"%position)
+
+    if "Maximum Number of Flex Starters" in dat.parameters:
+        players = {player_name for player_name in can_be_drafted_by_me if
+                   dat.roster_requirements[dat.players[player_name]["Position"]]["Flex Status"] == "Flex Eligible"}
+        m.add_constraint(m.sum(my_starters[player_name] for player_name in players)
+                         <= dat.parameters["Maximum Number of Flex Starters"]["Value"],
+                         ctname = "max_flex")
+
+    starter_weight = dat.parameters["Starter Weight"]["Value"] if "Starter Weight" in dat.parameters else 1
+    reserve_weight = dat.parameters["Reserve Weight"]["Value"] if "Reserve Weight" in dat.parameters else 1
+    m.maximize(m.sum(dat.players[player_name]["Expected Points"] *
+                    (my_starters[player_name] * starter_weight + my_reserves[player_name] * reserve_weight)
+                    for player_name in can_be_drafted_by_me))
+
+
+    if not m.solve():
+        print "failed to solve"
+        return
+
+    sln = solutionFactory.TicDat()
+    cplex_soln = m.solution
+    def almostone(x) :
+        return abs(cplex_soln.get_value(x)-1) < 0.0001
+    picked = sorted([player_name for player_name in can_be_drafted_by_me
+                     if almostone(my_starters[player_name]) or almostone(my_reserves[player_name])],
+                    key=lambda _p: expected_draft_position[_p])
+    assert len(picked) <= len(dat.my_draft_positions)
+    if len(picked) < len(dat.my_draft_positions):
+        print "Your model is over-constrained, and thus only a partial draft was possible"
+
+    for player_name, draft_position in zip(picked, sorted(dat.my_draft_positions)):
+        assert draft_position <= expected_draft_position[player_name]
+        sln.my_draft[player_name]["Draft Position"] = draft_position
+        sln.my_draft[player_name]["Position"] = dat.players[player_name]["Position"]
+        sln.my_draft[player_name]["Planned Or Actual"] = "Actual" if player_name in already_drafted_by_me else "Planned"
+        sln.my_draft[player_name]["Starter Or Reserve"] = "Starter" if almostone(my_starters[player_name]) else "Reserve"
+
+    return sln
+# ---------------------------------------------------------------------------------
+
+# ------------------------ provide stand-alone functionality ----------------------
+# when run from the command line, will read/write xls/csv/db/mdb files
+if __name__ == "__main__":
+    standard_main(dataFactory, solutionFactory, solve)
+# ---------------------------------------------------------------------------------

--- a/examples/cplex/fantop/fantopmodel.py
+++ b/examples/cplex/fantop/fantopmodel.py
@@ -6,7 +6,7 @@
 # positions (to include a maximum-flex-players constraint).
 #
 # Pre-computes the expected draft position of each player, so as to prevent
-# creating an draft plan based on unrealistic expectations of player availability
+# creating a draft plan based on unrealistic expectations of player availability
 # at each round.
 #
 # The current draft standing can be filled in as you go in the drafted table.

--- a/examples/gurobi/cog/cogmodel.py
+++ b/examples/gurobi/cog/cogmodel.py
@@ -1,6 +1,18 @@
 #!/usr/bin/python
-
+#
 # Copyright 2015, Opalytics, Inc
+#
+# Be advised - although this is the first ticdat example alphabetically, it is not the
+# first example intellectually. I strongly recommend beginning with the diet example,
+# and follow that with either netflow/simplest_version or fantop. These three examples
+# demonstrate the ability of ticdat to easily provide a command line interface
+# (complete with sanity checking of the input data) that can accommodate a variety
+# of file formats.
+#
+# This example demonstrates a script that is capable of fully exploiting all the bells and
+# whistles of the Opalytics Cloud Platform. It pre-diagnoses infeasibility conditions and
+# records them in a log file. It also keeps track of the MIP progress, and allows for the user
+# to terminate the solve prior to achieving the "a priori" goal for the optimization gap.
 #
 # Solve the Center of Gravity problem from _A Deep Dive into Strategic Network Design Programming_
 # http://amzn.to/1Lbd6By

--- a/examples/gurobi/fantop/fantopmodel.py
+++ b/examples/gurobi/fantop/fantopmodel.py
@@ -1,0 +1,175 @@
+#
+# Author: Pete Cacioppi Opalytics.com
+#
+# Solves a fantasy football drafting problem. Tries to maximize the weighted
+# expected points of a draft, while obeying min/max restrictions for different
+# positions (to include a maximum-flex-players constraint).
+#
+# Pre-computes the expected draft position of each player, so as to prevent
+# creating an draft plan based on unrealistic expectaions of player availability
+# at each round.
+#
+# The current draft standing can be filled in as you go in the drafted table.
+# A user can thus re-optimize for each of his draft picks.
+#
+# Uses the ticdat package to simplify file IO and provide command line functionality.
+# Can read from .csv, Access, Excel or SQLite files. Self validates the input data
+# before solving to prevent strange errors or garbage-in, garbage-out problems.
+
+from ticdat import TicDatFactory, standard_main
+
+
+# this version of the file uses Gurobi
+import gurobipy as gu
+
+# ------------------------ define the input schema --------------------------------
+dataFactory = TicDatFactory (
+ parameters = [["Key"],["Value"]],
+ players = [['Player Name'],
+            ['Position', 'Average Draft Position', 'Expected Points']],
+ roster_requirements = [['Position'],
+                       ['Min Num Starters', 'Max Num Starters', 'Min Num Reserve', 'Max Num Reserve',
+                        'Flex Status']],
+ drafted = [['Player Name'], ['Draft Position']],
+ my_draft_positions = [['Draft Position'],[]]
+)
+
+# add foreign key constraints (optional, but helps with preventing garbage-in, garbage-out)
+dataFactory.add_foreign_key("drafted", "players", ['Player Name', 'Player Name'])
+dataFactory.add_foreign_key("players", "roster_requirements", ['Position', 'Position'])
+
+# set data types (optional, but helps with preventing garbage-in, garbage-out)
+dataFactory.set_data_type("parameters", "Key", number_allowed = False,
+                          strings_allowed = ["Starter Weight", "Reserve Weight",
+                                             "Maximum Number of Flex Starters"])
+dataFactory.set_data_type("parameters", "Value", min=0, max=float("inf"),
+                          inclusive_min = True, inclusive_max = False)
+dataFactory.set_data_type("players", "Average Draft Position", min=0, max=float("inf"),
+                          inclusive_min = False, inclusive_max = False)
+dataFactory.set_data_type("players", "Expected Points", min=-float("inf"), max=float("inf"),
+                          inclusive_min = False, inclusive_max = False)
+for fld in ("Min Num Starters",  "Min Num Reserve", "Max Num Reserve"):
+    dataFactory.set_data_type("roster_requirements", fld, min=0, max=float("inf"),
+                          inclusive_min = True, inclusive_max = False, must_be_int = True)
+dataFactory.set_data_type("roster_requirements", "Max Num Starters", min=0, max=float("inf"),
+                      inclusive_min = False, inclusive_max = True, must_be_int = True)
+dataFactory.set_data_type("roster_requirements", "Flex Status", number_allowed = False,
+                          strings_allowed = ["Flex Eligible", "Flex Ineligible"])
+for tbl in ("drafted", "my_draft_positions"):
+    dataFactory.set_data_type(tbl, "Draft Position", min=0, max=float("inf"),
+                          inclusive_min = False, inclusive_max = False, must_be_int = True)
+# ---------------------------------------------------------------------------------
+
+
+# ------------------------ define the output schema -------------------------------
+solutionFactory = TicDatFactory(
+        my_draft = [['Player Name'], ['Draft Position', 'Position', 'Planned Or Actual',
+                                     'Starter Or Reserve']])
+# ---------------------------------------------------------------------------------
+
+
+# ------------------------ create a solve function --------------------------------
+def solve(dat):
+    assert dataFactory.good_tic_dat_object(dat)
+    assert not dataFactory.find_foreign_key_failures(dat)
+    assert not dataFactory.find_data_type_failures(dat)
+    if dat.drafted:
+        draft_positions = {x["Draft Position"] for x in dat.drafted.values()}
+        assert min(draft_positions) == 1 and len(draft_positions) == max(draft_positions), \
+               "draft positions should be sequential"
+
+    # if a player has already been drafted, then we know his expected draft position
+    expected_draft_position = {player_name:row["Draft Position"] for player_name,row in
+                               dat.drafted.items()}
+    # the undrafted players are then sorted by their average draft position
+    for player_name in sorted([p for p in set(dat.players).difference(expected_draft_position)],
+                                          key=lambda _p: dat.players[_p]["Average Draft Position"]):
+        expected_draft_position[player_name] = len(expected_draft_position) + 1
+    assert max(expected_draft_position.values()) == len(set(expected_draft_position.values())) == len(dat.players)
+    assert min(expected_draft_position.values()) == 1
+
+    already_drafted_by_me = {player_name for player_name in dat.drafted if
+                             dat.drafted[player_name]["Draft Position"] in dat.my_draft_positions}
+    can_be_drafted_by_me = set(dat.players).difference(dat.drafted).union(already_drafted_by_me)
+    m = gu.Model('fantop')
+    my_starters = {}
+    my_reserves = {}
+    for player_name in can_be_drafted_by_me:
+        my_starters[player_name] = m.addVar(vtype=gu.GRB.BINARY, name="starter_%s"%player_name)
+        my_reserves[player_name] = m.addVar(vtype=gu.GRB.BINARY, name="reserve_%s"%player_name)
+
+    m.update()
+
+    for player_name in can_be_drafted_by_me:
+        if player_name in already_drafted_by_me:
+            m.addConstr(my_starters[player_name] + my_reserves[player_name] == 1,
+                        name="already_drafted_%s"%player_name)
+        else:
+            m.addConstr(my_starters[player_name] + my_reserves[player_name] <= 1,
+                        name="cant_draft_twice_%s"%player_name)
+
+    for i,draft_position in enumerate(sorted(dat.my_draft_positions)):
+        m.addConstr(gu.quicksum(my_starters[player_name] + my_reserves[player_name]
+                                for player_name in can_be_drafted_by_me
+                                if expected_draft_position[player_name] < draft_position) <= i,
+                    name = "at_most_%s_can_be_ahead_of_%s"%(i,draft_position))
+
+    my_draft_size = gu.quicksum(my_starters[player_name] + my_reserves[player_name]
+                                for player_name in can_be_drafted_by_me)
+    m.addConstr(my_draft_size >= len(already_drafted_by_me) + 1, name = "need_to_extend_by_at_least_one")
+    m.addConstr(my_draft_size <= len(dat.my_draft_positions), name = "cant_exceed_draft_total")
+
+    for position, row in dat.roster_requirements.items():
+        players = {player_name for player_name in can_be_drafted_by_me
+                   if dat.players[player_name]["Position"] == position}
+        starters = gu.quicksum(my_starters[player_name] for player_name in players)
+        reserves = gu.quicksum(my_reserves[player_name] for player_name in players)
+        m.addConstr(starters >= row["Min Num Starters"], name = "min_starters_%s"%position)
+        m.addConstr(starters <= row["Max Num Starters"], name = "max_starters_%s"%position)
+        m.addConstr(reserves >= row["Min Num Reserve"], name = "min_reserve_%s"%position)
+        m.addConstr(reserves <= row["Max Num Reserve"], name = "max_reserve_%s"%position)
+
+    if "Maximum Number of Flex Starters" in dat.parameters:
+        players = {player_name for player_name in can_be_drafted_by_me if
+                   dat.roster_requirements[dat.players[player_name]["Position"]]["Flex Status"] == "Flex Eligible"}
+        m.addConstr(gu.quicksum(my_starters[player_name] for player_name in players)
+                    <= dat.parameters["Maximum Number of Flex Starters"]["Value"],
+                    name = "max_flex")
+
+    starter_weight = dat.parameters["Starter Weight"]["Value"] if "Starter Weight" in dat.parameters else 1
+    reserve_weight = dat.parameters["Reserve Weight"]["Value"] if "Reserve Weight" in dat.parameters else 1
+    m.setObjective(gu.quicksum(dat.players[player_name]["Expected Points"] *
+                               (my_starters[player_name] * starter_weight + my_reserves[player_name] * reserve_weight)
+                               for player_name in can_be_drafted_by_me),
+                   gu.GRB.MAXIMIZE)
+
+    m.optimize()
+    if m.status != gu.GRB.OPTIMAL:
+        print "No draft at all is possible!"
+        return
+
+    sln = solutionFactory.TicDat()
+    def almostone(x) :
+        return abs(x.x-1) < 0.0001
+    picked = sorted([player_name for player_name in can_be_drafted_by_me
+                     if almostone(my_starters[player_name]) or almostone(my_reserves[player_name])],
+                    key=lambda _p: expected_draft_position[_p])
+    assert len(picked) <= len(dat.my_draft_positions)
+    if len(picked) < len(dat.my_draft_positions):
+        print "Your model is over-constrained, and thus only a partial draft was possible"
+
+    for player_name, draft_position in zip(picked, sorted(dat.my_draft_positions)):
+        assert draft_position <= expected_draft_position[player_name]
+        sln.my_draft[player_name]["Draft Position"] = draft_position
+        sln.my_draft[player_name]["Position"] = dat.players[player_name]["Position"]
+        sln.my_draft[player_name]["Planned Or Actual"] = "Actual" if player_name in already_drafted_by_me else "Planned"
+        sln.my_draft[player_name]["Starter Or Reserve"] = "Starter" if almostone(my_starters[player_name]) else "Reserve"
+
+    return sln
+# ---------------------------------------------------------------------------------
+
+# ------------------------ provide stand-alone functionality ----------------------
+# when run from the command line, will read/write xls/csv/db/mdb files
+if __name__ == "__main__":
+    standard_main(dataFactory, solutionFactory, solve)
+# ---------------------------------------------------------------------------------

--- a/examples/gurobi/fantop/fantopmodel.py
+++ b/examples/gurobi/fantop/fantopmodel.py
@@ -1,5 +1,5 @@
 #
-# Author: Pete Cacioppi Opalytics.com
+# Author: Pete Cacioppi Opalytics.com https://lnkd.in/bUhfyNn
 #
 # Solves a fantasy football drafting problem. Tries to maximize the weighted
 # expected points of a draft, while obeying min/max restrictions for different

--- a/examples/gurobi/fantop/fantopmodel.py
+++ b/examples/gurobi/fantop/fantopmodel.py
@@ -6,7 +6,7 @@
 # positions (to include a maximum-flex-players constraint).
 #
 # Pre-computes the expected draft position of each player, so as to prevent
-# creating an draft plan based on unrealistic expectaions of player availability
+# creating a draft plan based on unrealistic expectations of player availability
 # at each round.
 #
 # The current draft standing can be filled in as you go in the drafted table.

--- a/ticdat.txt
+++ b/ticdat.txt
@@ -441,6 +441,10 @@ CLASSES
      |      ex: TicDatFactory (categories =  [["name"],["minNutrition", "maxNutrition"]],
      |                         foods  =  [["name"],["cost"]]
      |                         nutritionQuantities = [["food", "category"],["qty"]])
+     |                         Use '*' instead of a pair of lists for generic tables,
+     |                         which will render as pandas.DataFrame objects.
+     |      ex: TicDatFactory (typical_table = [["primary key field"],["data field"]],
+     |                         generic_table = '*')
      |      :return: a TicDatFactory
      |  
      |  add_foreign_key(self, native_table, foreign_table, mappings)

--- a/ticdat.txt
+++ b/ticdat.txt
@@ -328,11 +328,12 @@ CLASSES
      |      :param db_file_path: the file path of the SQLite database to create
      |      :return:
      |  
-     |  write_sql_file(self, tic_dat, sql_file_path, include_schema=False)
+     |  write_sql_file(self, tic_dat, sql_file_path, include_schema=False, allow_overwrite = False)
      |      write the sql for the ticDat data to a text file
      |      :param tic_dat: the data object to write
      |      :param sql_file_path: the path of the text file to hold the sql statements for the data
      |      :param include_schema: boolean - should we write the schema sql first?
+     |      :param allow_overwrite: boolean - are we allowed to overwrite pre-existing file
      |      :return:
      |      caveats : float("inf"), float("-inf") are written as "inf", "-inf"
      |  
@@ -824,6 +825,8 @@ FUNCTIONS
         --> endings in ".xls" or ".xlsx" imply reading/writing Excel files
         --> endings in ".mdb" or ".accdb" imply reading/writing Access files
         --> ending in ".db" imply reading/writing SQLite files
+        --> ending in ".sql" imply reading/writing SQLite text files rendered in
+            schema-less SQL statements
         --> otherwise, the assumption is that an input/output directory is being specified,
             which will be used for reading/writing .csv files.
             (Recall that .csv format is implemented as one-csv-file-per-table, so an entire

--- a/ticdat/sqlitetd.py
+++ b/ticdat/sqlitetd.py
@@ -292,16 +292,20 @@ class SQLiteTicFactory(freezable_factory(object, "_isFrozen")) :
             for sql_str, data in self._get_data(tic_dat, as_sql=False):
                 con.execute(sql_str, list(data))
 
-    def write_sql_file(self, tic_dat, sql_file_path, include_schema = False):
+    def write_sql_file(self, tic_dat, sql_file_path, include_schema = False,
+                       allow_overwrite = False):
         """
         write the sql for the ticDat data to a text file
         :param tic_dat: the data object to write
         :param sql_file_path: the path of the text file to hold the sql statements for the data
         :param include_schema: boolean - should we write the schema sql first?
+        :param allow_overwrite: boolean - are we allowed to overwrite pre-existing file
         :return:
         caveats : float("inf"), float("-inf") are written as "inf", "-inf"
         """
         verify(sql, "sqlite3 needs to be installed to use this subroutine")
+        verify(allow_overwrite or not os.path.exists(sql_file_path),
+               "The %s path exists and overwrite is not allowed"%sql_file_path)
         with open(sql_file_path, "w") as f:
             for str in (self._get_schema_sql() if include_schema else ()) + \
                         self._get_data(tic_dat, as_sql=True):

--- a/ticdat/testing/testsql.py
+++ b/ticdat/testing/testsql.py
@@ -68,7 +68,7 @@ class TestSql(unittest.TestCase):
             changeit()
             self.assertFalse(tdf._same_data(ticDat, sqlTicDat))
 
-            tdf.sql.write_sql_file(ticDat, filePath, include_schema=True)
+            tdf.sql.write_sql_file(ticDat, filePath, include_schema=True, allow_overwrite=True)
             sqlTicDat = tdf.sql.create_tic_dat_from_sql(filePath, includes_schema=True, freeze_it=True)
             self.assertTrue(tdf._same_data(ticDat, sqlTicDat))
             self.assertTrue(self.firesException(changeit))

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -636,8 +636,9 @@ class TestUtils(unittest.TestCase):
             self.assertTrue((dat2.theTable[k]["fieldTwo"] == 0) ==
                             (k in [22.2, "22"]))
         fnd = tdf.find_data_type_failures(dat2)
-        self.assertTrue(len(fnd) == 1 and len(fnd.values()[0].pks)==2)
-        self.assertTrue(set(fnd.values()[0].pks) == set(fnd.values()[0].bad_values))
+        fnd_values = list(fnd.values())
+        self.assertTrue(len(fnd) == 1 and len(fnd_values[0].pks)==2)
+        self.assertTrue(set(fnd_values[0].pks) == set(fnd_values[0].bad_values))
 
     def testSixteen(self):
         def makeTdfDat(add_integrality_rule = False):

--- a/ticdat/testing/testutils.py
+++ b/ticdat/testing/testutils.py
@@ -635,6 +635,10 @@ class TestUtils(unittest.TestCase):
         for k in dat2.theTable:
             self.assertTrue((dat2.theTable[k]["fieldTwo"] == 0) ==
                             (k in [22.2, "22"]))
+        fnd = tdf.find_data_type_failures(dat2)
+        self.assertTrue(len(fnd) == 1 and len(fnd.values()[0].pks)==2)
+        self.assertTrue(set(fnd.values()[0].pks) == set(fnd.values()[0].bad_values))
+
 
 
 _scratchDir = TestUtils.__name__ + "_scratch"

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -414,6 +414,10 @@ foreign keys, the code throwing this exception will be removed.
         ex: TicDatFactory (categories =  [["name"],["minNutrition", "maxNutrition"]],
                            foods  =  [["name"],["cost"]]
                            nutritionQuantities = [["food", "category"],["qty"]])
+                           Use '*' instead of a pair of lists for generic tables,
+                           which will render as pandas.DataFrame objects.
+        ex: TicDatFactory (typical_table = [["primary key field"],["data field"]],
+                           generic_table = '*')
         :return: a TicDatFactory
         """
         self._has_been_used = [] # append to this to make it truthy

--- a/ticdat/ticdatfactory.py
+++ b/ticdat/ticdatfactory.py
@@ -1020,10 +1020,16 @@ foreign keys, the code throwing this exception will be removed.
             verify(self._data_types[table][field].valid_data(value),
                    "The replacement value %s is not itself valid for %s : %s"%(value, table, field))
 
-        for (table, field), (_, pks) in replacements_needed.items() :
+        for (table, field), (vals, pks) in replacements_needed.items() :
             if (table, field) in real_replacements:
-                for pk in pks:
-                    getattr(tic_dat, table)[pk][field] = real_replacements[table, field]
+                if pks is not None :
+                    for pk in pks:
+                        getattr(tic_dat, table)[pk][field] = real_replacements[table, field]
+                else :
+                    vals = set(vals)
+                    for row in getattr(tic_dat, table):
+                        if row[field] in vals:
+                            row[field] = real_replacements[table, field]
 
         assert not set(self.find_data_type_failures(tic_dat)).intersection(real_replacements)
         return tic_dat

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -466,7 +466,7 @@ class Sloc(object):
             if isinstance(s, pd.DataFrame):
             # adding sloc just to the columns of the DataFrame and not to the DataFrame itself.
                 for c in s.columns:
-                    Sloc.add_sloc(getattr(s,c))
+                    Sloc.add_sloc(s[c])
             else:
                 s.sloc = Sloc(s)
             return s

--- a/ticdat/utils.py
+++ b/ticdat/utils.py
@@ -69,10 +69,10 @@ def standard_main(dataFactory, solutionFactory, solve):
                                 (".xls", ".xlsx", ".db", ".sql", ".mdb", ".accdb")) \
                   else "directory"
     if not (os.path.exists(input_file)):
-        print "%s is not a valid input file or directory"%input_file
+        print("%s is not a valid input file or directory"%input_file)
     else:
-        print "input %s %s : output %s %s"%(file_or_dir(input_file), input_file,
-                                            file_or_dir(output_file), output_file)
+        print("input %s %s : output %s %s"%(file_or_dir(input_file), input_file,
+                                            file_or_dir(output_file), output_file))
         dat = None
         if os.path.isfile(input_file) and file_or_dir(input_file) == "file":
             if input_file.endswith(".xls") or input_file.endswith(".xlsx"):
@@ -93,8 +93,8 @@ def standard_main(dataFactory, solutionFactory, solve):
         verify(dat, "Failed to read from and/or recognize %s"%input_file)
         sln = solve(dat)
         if sln:
-            print "%s output %s %s"%("Overwriting" if os.path.exists(output_file) else "Creating",
-                                     file_or_dir(output_file), output_file)
+            print("%s output %s %s"%("Overwriting" if os.path.exists(output_file) else "Creating",
+                                     file_or_dir(output_file), output_file))
             if output_file.endswith(".xls") or output_file.endswith(".xlsx"):
                 solutionFactory.xls.write_file(sln, output_file, allow_overwrite=True)
             elif output_file.endswith(".db"):
@@ -106,7 +106,7 @@ def standard_main(dataFactory, solutionFactory, solve):
             else:
                 solutionFactory.csv.write_directory(sln, output_file, allow_overwrite=True)
         else:
-            print "No solution was created!"
+            print("No solution was created!")
 
 def verify(b, msg) :
     if not b :


### PR DESCRIPTION
Generic tables are those where the schema isn't known ahead of time. They will be rendered as `pandas.DataFrame` objects. 

Generic tables are recommended for Machine Learning functionality. MIP applications (and prescriptive analytics in general) tends to be built for a specific schema.