### PR TITLE
Better missing tables

### DIFF
--- a/ticdat.txt
+++ b/ticdat.txt
@@ -147,7 +147,7 @@ CLASSES
      |      :return: a TicDat object populated by the matching tables.
      |      caveats: Table names matches are case insensitive and also
      |               underscore-space insensitive.
-     |               Tables that don't find a match are inteprested as an empty table.
+     |               Tables that don't find a match are interpreted as an empty table.
      |               Dictionary keys that don't match any table are ignored.
      |
      |  find_duplicates(self, json_file_path)

--- a/ticdat/csvtd.py
+++ b/ticdat/csvtd.py
@@ -68,6 +68,10 @@ class CsvTicFactory(freezable_factory(object, "_isFrozen")) :
         verify(os.path.isdir(dir_path), "Invalid directory path %s"%dir_path)
         rtn =  {t : self._create_table(dir_path, t, dialect, headers_present)
                 for t in self.tic_dat_factory.all_tables}
+        missing_tables = {t for t in self.tic_dat_factory.all_tables if not rtn[t]}
+        if missing_tables:
+            print ("The following table names could not be found in the %s directory.\n%s\n"%
+                   (dir_path,"\n".join(missing_tables)))
         return {k:v for k,v in rtn.items() if v}
     def find_duplicates(self, dir_path, dialect='excel', headers_present = True):
         """

--- a/ticdat/jsontd.py
+++ b/ticdat/jsontd.py
@@ -63,7 +63,7 @@ class JsonTicFactory(freezable_factory(object, "_isFrozen")) :
         :return: a TicDat object populated by the matching tables.
         caveats: Table names matches are case insensitive and also
                  underscore-space insensitive.
-                 Tables that don't find a match are inteprested as an empty table.
+                 Tables that don't find a match are interpreted as an empty table.
                  Dictionary keys that don't match any table are ignored.
         """
         _standard_verify(self.tic_dat_factory)

--- a/ticdat/jsontd.py
+++ b/ticdat/jsontd.py
@@ -68,7 +68,12 @@ class JsonTicFactory(freezable_factory(object, "_isFrozen")) :
         """
         _standard_verify(self.tic_dat_factory)
         jdict = self._create_jdict(json_file_path)
-        rtn = self.tic_dat_factory.TicDat(**self._create_tic_dat_dict(jdict))
+        tic_dat_dict = self._create_tic_dat_dict(jdict)
+        missing_tables = set(self.tic_dat_factory.all_tables).difference(tic_dat_dict)
+        if missing_tables:
+            print ("The following table names could not be found in the %s file.\n%s\n"%
+                   (json_file_path,"\n".join(missing_tables)))
+        rtn = self.tic_dat_factory.TicDat(**tic_dat_dict)
         if freeze_it:
             return self.tic_dat_factory.freeze_me(rtn)
         return rtn

--- a/ticdat/testing/testjson.py
+++ b/ticdat/testing/testjson.py
@@ -84,6 +84,29 @@ class TestJson(unittest.TestCase):
             jsonTicDat = tdf.json.create_tic_dat(writePath)
             self.assertTrue(tdf._same_data(ticDat, jsonTicDat))
 
+    def testMissingTable(self):
+        if not self.can_run:
+            return
+        tdf = TicDatFactory(**dietSchema())
+        tdf2 = TicDatFactory(**{k:v for k,v in dietSchema().items() if k != "nutritionQuantities"})
+        ticDat2 = tdf2.copy_tic_dat(dietData())
+        filePath = os.path.join(_scratchDir, "diet_missing.json")
+        tdf2.json.write_file(ticDat2, filePath, allow_overwrite=True)
+        ticDat3 = tdf.json.create_tic_dat(filePath)
+        self.assertTrue(tdf2._same_data(ticDat2, ticDat3))
+        self.assertTrue(all(hasattr(ticDat3, x) for x in tdf.all_tables))
+        self.assertFalse(ticDat3.nutritionQuantities)
+        self.assertTrue(ticDat3.categories and ticDat3.foods)
+
+        tdf2 = TicDatFactory(**{k:v for k,v in dietSchema().items() if k == "categories"})
+        ticDat2 = tdf2.copy_tic_dat(dietData())
+        tdf2.json.write_file(ticDat2, filePath, allow_overwrite=True)
+        ticDat3 = tdf.json.create_tic_dat(filePath)
+        self.assertTrue(tdf2._same_data(ticDat2, ticDat3))
+        self.assertTrue(all(hasattr(ticDat3, x) for x in tdf.all_tables))
+        self.assertFalse(ticDat3.nutritionQuantities or ticDat3.foods)
+        self.assertTrue(ticDat3.categories)
+
     def testNetflow(self):
         if not self.can_run:
             return

--- a/ticdat/testing/testxls.py
+++ b/ticdat/testing/testxls.py
@@ -82,6 +82,31 @@ class TestXls(unittest.TestCase):
         self.assertFalse(tdf._same_data(xlsTicDat, ticDat))
         self.assertTrue(all(len(getattr(ticDat, t))-1 == len(getattr(xlsTicDat, t)) for t in tdf.all_tables))
 
+    def testMissingTable(self):
+        if not self.can_run:
+            return
+        tdf = TicDatFactory(**dietSchema())
+        tdf2 = TicDatFactory(**{k:v for k,v in dietSchema().items() if k != "nutritionQuantities"})
+        ticDat2 = tdf2.copy_tic_dat(dietData())
+        filePath = makeCleanPath(os.path.join(_scratchDir, "diet_missing.xlsx"))
+        tdf2.xls.write_file(ticDat2, filePath)
+        ticDat3 = tdf.xls.create_tic_dat(filePath)
+        self.assertTrue(tdf2._same_data(ticDat2, ticDat3))
+        self.assertTrue(all(hasattr(ticDat3, x) for x in tdf.all_tables))
+        self.assertFalse(ticDat3.nutritionQuantities)
+        self.assertTrue(ticDat3.categories and ticDat3.foods)
+
+        tdf2 = TicDatFactory(**{k:v for k,v in dietSchema().items() if k == "categories"})
+        ticDat2 = tdf2.copy_tic_dat(dietData())
+        filePath = makeCleanPath(os.path.join(_scratchDir, "diet_missing.xlsx"))
+        tdf2.xls.write_file(ticDat2, filePath)
+        ticDat3 = tdf.xls.create_tic_dat(filePath)
+        self.assertTrue(tdf2._same_data(ticDat2, ticDat3))
+        self.assertTrue(all(hasattr(ticDat3, x) for x in tdf.all_tables))
+        self.assertFalse(ticDat3.nutritionQuantities or ticDat3.foods)
+        self.assertTrue(ticDat3.categories)
+
+
     def testNetflow(self):
         if not self.can_run:
             return


### PR DESCRIPTION
Missing tables should either throw exceptions (for database reads) or print warnings (for normal file reads).